### PR TITLE
docs: add libFuzzer plan and clarify Windows artifacts

### DIFF
--- a/build/windows/README.md
+++ b/build/windows/README.md
@@ -2,3 +2,28 @@
 
 - [Build instruction for Windows x32](../../.github/workflows/build_and_publish_win_x32_wheels_for_many_python_versions.yaml).
 - [Build instruction for Windows x64](../../.github/workflows/build_and_publish_win_x64_wheels_for_many_python_versions.yaml).
+
+## What artifact do you get (`dll`/`exe`)?
+
+From this repository, the primary Windows output is a **Python extension module**:
+
+- `tgcalls.pyd` (this is a DLL loaded by Python)
+
+It is packaged into wheel files (for example in CI):
+
+- `tgcalls-<version>-cp<pyver>-cp<pyver>-win_amd64.whl`
+- `pytgcalls-<version>-py3-none-any.whl` (pure Python package)
+
+So for your question: this repo normally builds a **`.pyd`/DLL-style module inside a wheel**, not a standalone EXE.
+
+## Typical local build flow
+
+1. Build wheel with the existing workflow logic/toolchain.
+2. Install wheel in a Python environment.
+3. Verify import:
+
+```powershell
+python -c "import tgcalls; print(tgcalls.__doc__)"
+```
+
+If you need an EXE, that would be a separate wrapper app (Python or C++) that links/loads the built module.

--- a/docs/FUZZING_PLAN.md
+++ b/docs/FUZZING_PLAN.md
@@ -1,0 +1,192 @@
+# libFuzzer harness layout for `tgcalls`
+
+This document proposes a concrete fuzzing layout for this repository, focused on Telegram call signaling and call setup surfaces exposed through the C++ binding.
+
+## Why these targets
+
+The Python extension exposes call-signaling entrypoints through `NativeInstance`:
+
+- `startCall(...)`
+- `receiveSignalingData(...)`
+- `setSignalingDataEmittedCallback(...)`
+
+Those are exported in the binding and route data to Telegram's native call stack, making them the best first fuzz surfaces.
+
+## Directory layout
+
+```text
+tgcalls/
+  fuzz/
+    CMakeLists.txt
+    common/
+      FuzzInit.h
+      FuzzInputReader.h
+      FuzzInputReader.cpp
+      SeedCorpusNotes.md
+    targets/
+      signaling_packet_fuzzer.cc
+      signaling_sequence_fuzzer.cc
+      startcall_descriptor_fuzzer.cc
+  fuzz/corpus/
+    signaling_packet/
+    signaling_sequence/
+    startcall_descriptor/
+```
+
+You can also keep corpus under repo root (`fuzz/corpus/...`) if preferred by CI.
+
+## Target 1: `signaling_packet_fuzzer` (highest priority)
+
+**Goal:** mutate one signaling blob and feed it into a minimally initialized call instance.
+
+### Harness shape
+
+1. Build one `NativeInstance` once per process (or per iteration if stability requires).
+2. Provide deterministic dummy `RtcServer` list and fixed 256-byte auth key.
+3. Call `startCall(...)` with outgoing/incoming mode from fuzz data.
+4. Parse the fuzz buffer into one packet (bounded size).
+5. Call `receiveSignalingData(packet)`.
+
+### Suggested entry function
+
+```cpp
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // parse -> init call -> receiveSignalingData
+  return 0;
+}
+```
+
+### Useful guardrails
+
+- Cap packet length (for example `<= 64 KiB`) to avoid pathological allocation.
+- Wrap only expected runtime exceptions from harness plumbing (not import-time operations).
+- Skip empty packet early.
+
+## Target 2: `signaling_sequence_fuzzer` (stateful)
+
+**Goal:** fuzz ordering/state transitions by sending multiple packets.
+
+### Input format
+
+Use a tiny binary framing format:
+
+- `u8 packet_count` (0..16)
+- repeated:
+  - `u16 len`
+  - `len` bytes payload
+
+### Execution
+
+1. Initialize `NativeInstance` once.
+2. `startCall(...)` once.
+3. Replay `packet_count` blobs via `receiveSignalingData(...)`.
+4. Optionally toggle network type / mute / restart audio device between packets (if exposed safely).
+
+This catches parser + state-machine bugs that single-packet fuzzing misses.
+
+## Target 3: `startcall_descriptor_fuzzer` (constructor/config path)
+
+**Goal:** fuzz inputs used by `startCall(...)` itself.
+
+### Mutated fields
+
+- Number of RTC servers (bounded, e.g. 0..8)
+- Server host strings (UTF-8/invalid bytes normalized to safe strings)
+- Port values
+- `isTurn` / `isStun` combinations
+- Username/password lengths
+- `isOutgoing` flag
+- Auth key bytes (always exactly 256 bytes by deriving from input)
+
+### Expected value
+
+This exercises call descriptor assembly and server-list handling before signaling data is processed.
+
+## Corpus seeding plan
+
+Seed each target with both **structure-aware** and **chaos** samples.
+
+### `signaling_packet` corpus
+
+Start with:
+
+- Empty (`""`)
+- 1-byte, 2-byte, 3-byte packets
+- All-zero 64B / 512B
+- All-`0xFF` 64B / 512B
+- Valid-ish packet captures (if available from local test harness)
+
+### `signaling_sequence` corpus
+
+- 0 packets
+- 1 packet with tiny payload
+- 2 packets with same payload
+- 4 packets with increasing lengths
+- A captured real sequence from test traffic (redacted)
+
+### `startcall_descriptor` corpus
+
+- 0 servers
+- 1 STUN only
+- 1 TURN only
+- Mixed STUN+TURN entries
+- Max bounded entries with long credentials
+
+### Corpus growth workflow
+
+1. Run each fuzzer with `-merge=1` into canonical corpus.
+2. Keep crashers in `fuzz/artifacts/<target>/`.
+3. Minimize with `-minimize_crash=1`.
+
+## Sanitizer flags
+
+For Linux/macOS Clang fuzz builds:
+
+- **Required for first pass:**
+  - `-fsanitize=fuzzer,address,undefined`
+- **Recommended follow-up runs:**
+  - `-fsanitize=fuzzer,no-link` for library objects + link in fuzz target
+  - `-fsanitize=integer` (if toolchain supports and noise is manageable)
+
+Recommended runtime options:
+
+```bash
+ASAN_OPTIONS=detect_leaks=1:strict_string_checks=1:check_initialization_order=1
+UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
+```
+
+For long fuzzing jobs, prefer:
+
+- `-max_len=65536`
+- `-timeout=10`
+- `-rss_limit_mb=4096`
+
+## CMake integration sketch
+
+Add an option in root CMake:
+
+- `option(TGCALLS_ENABLE_FUZZING "Build fuzz targets" OFF)`
+- `if(TGCALLS_ENABLE_FUZZING) add_subdirectory(tgcalls/fuzz) endif()`
+
+In `tgcalls/fuzz/CMakeLists.txt`:
+
+1. Detect Clang and libFuzzer support.
+2. Build a reusable harness support library from `common/*`.
+3. Add 3 executables for targets.
+4. Link target binaries to the same core dependencies used by the extension where possible.
+5. Apply sanitizer/fuzzer flags only for fuzz targets.
+
+## CI suggestions
+
+- Add one quick smoke run per target (`-runs=200`) on PRs.
+- Run longer jobs nightly with corpus upload/download.
+- Upload sanitizer reports + minimized crash artifacts.
+
+## Windows note
+
+`libFuzzer` is best supported with Clang/LLVM toolchains. For Windows fuzzing:
+
+- Prefer **clang-cl + AddressSanitizer** for local fuzz-like mutation harnesses.
+- For pure MSVC, keep deterministic unit-style repro runners for crashing inputs.
+
+The normal project Windows output is still the Python extension module (`tgcalls.pyd`, a DLL), not a standalone EXE.


### PR DESCRIPTION
## **User description**
### Motivation
- Provide a concrete, actionable libFuzzer harness layout tailored to the repository's call-signaling surfaces so fuzzing can start quickly. 
- Clarify what Windows build artifacts this project produces so maintainers/users know the expected outputs and how to validate a local build.

### Description
- Add `docs/FUZZING_PLAN.md` with three recommended fuzz targets (`signaling_packet`, `signaling_sequence`, `startcall_descriptor`), corpus seeding guidance, sanitizer flags, runtime options, and a CMake integration sketch. 
- Propose a repository layout for fuzz sources and corpora and describe harness shapes, input formats, and guardrails for each target. 
- Update `build/windows/README.md` to state that the primary Windows artifact is `tgcalls.pyd` (a DLL-style Python extension packaged into wheels) and add a minimal import verification example (`python -c "import tgcalls; print(tgcalls.__doc__)"`).

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch errors and the changes are limited to documentation. 
- No runtime or build-code changes were made, so no binary tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ff615ab08331843012d9eaf96187)

## Summary by Sourcery

Document a concrete libFuzzer harness layout for tgcalls and clarify the primary Windows build artifacts and typical verification flow.

Documentation:
- Add a detailed libFuzzer fuzzing plan outlining recommended targets, corpus structure, sanitizer configuration, and CMake/CI integration guidance.
- Expand the Windows build README to clarify that the main output is the tgcalls.pyd Python extension inside wheels and describe a simple import-based verification workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs/FUZZING_PLAN.md with a concrete libFuzzer harness plan for Telegram call signaling (three targets, corpus seeding, sanitizer flags, runtime options, and a CMake sketch). Updates build/windows/README.md to clarify the primary Windows artifact is tgcalls.pyd (packaged in wheels) and includes a simple import verification command.

<sup>Written for commit a2898744b0c437fb88a73e47f07f97b49354047e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Add libFuzzer plan for tgcalls and clarify Windows build artifacts**

### What Changed
- Added a detailed libFuzzer fuzzing plan (docs/FUZZING_PLAN.md) with three concrete targets (single packet, packet sequences, and start-call descriptor), example corpus layouts, sanitizer/runtime recommendations, CMake integration sketch, and CI suggestions so maintainers can start fuzzing call-signaling surfaces quickly.
- Updated Windows build README (build/windows/README.md) to state the primary Windows output is a Python extension module (`tgcalls.pyd` inside wheels), show example wheel names, and provide a simple local verification command to confirm the build imports correctly.
- Included practical guidance for corpus seeding, crash handling, and suggested runtime limits so fuzz runs produce actionable artifacts and reproducible repros.

### Impact
`✅ Faster fuzzing setup for call-signaling code`
`✅ Clearer Windows artifact expectations for local builds`
`✅ Easier local verification via a simple import check`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Windows build documentation with comprehensive explanations of build artifacts, wheel packaging, local build workflows, verification steps, and clarifications on standalone executable requirements.
  * Added detailed fuzzing plan documentation for the C++ binding layer, including test targets, harness designs, execution strategies, corpus management, and CI integration recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->